### PR TITLE
Use MyST parser instead of recommonmark

### DIFF
--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -16,7 +16,6 @@ import datetime
 import os
 import sys
 from m2r import MdInclude
-from recommonmark.transform import AutoStructify
 
 sys.path.insert(0, os.path.abspath("@PYTHON_PACKAGE_LOCATION@"))
 
@@ -61,7 +60,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinxcontrib.moderncmakedomain',
-    'recommonmark',
+    'myst_parser',  # to support Markdown
     'breathe',  # to define the C++ api with breathe-apidoc
 ]
 
@@ -229,14 +228,6 @@ todo_include_todos = True
 
 def setup(app):
     """ some tools for markdown parsing """
-    config = {
-        # 'url_resolver': lambda url: github_doc_root + url,
-        'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-    }
-    app.add_config_value('recommonmark_config', config, True)
-    app.add_transform(AutoStructify)
-
     # from m2r to make `mdinclude` work
     app.add_config_value('no_underscore_emphasis', False, 'env')
     app.add_config_value('m2r_parse_relative_links', False, 'env')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "breathe",
     "m2r",
     "mistune<2.0.0",
-    "recommonmark",
+    "myst-parser",
     "sphinx",
     "sphinx-rtd-theme",
     "sphinxcontrib-moderncmakedomain",


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

recommonmark is deprecated in favour of MyST.  I gave it a quick try and it seems replacing recommonmark with MyST ist very straight forward.

MySt has a quite a lot of [configuration parameters](https://myst-parser.readthedocs.io/en/latest/configuration.html) but I'm simply using the defaults for now.

This partially addresses #2.


## How I Tested

Build the documentation of blmc_drivers which contains both rst and markdown files.
It seems to be all good (there are no errors, all pages are rendered properly).
