### PR TITLE
Remove dependency on m2r (use MyST instead)

### DIFF
--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -15,7 +15,6 @@
 import datetime
 import os
 import sys
-from m2r import MdInclude
 
 sys.path.insert(0, os.path.abspath("@PYTHON_PACKAGE_LOCATION@"))
 
@@ -224,13 +223,3 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-
-def setup(app):
-    """ some tools for markdown parsing """
-    # from m2r to make `mdinclude` work
-    app.add_config_value('no_underscore_emphasis', False, 'env')
-    app.add_config_value('m2r_parse_relative_links', False, 'env')
-    app.add_config_value('m2r_anonymous_references', False, 'env')
-    app.add_config_value('m2r_disable_inline_math', False, 'env')
-    app.add_directive('mdinclude', MdInclude)

--- a/breathing_cat/resources/sphinx/index.rst.in
+++ b/breathing_cat/resources/sphinx/index.rst.in
@@ -19,4 +19,4 @@ Indices and Tables
 License and Copyrights
 ----------------------
 
-.. mdinclude:: license.txt
+.. include:: license.txt

--- a/breathing_cat/resources/sphinx/index.rst.in
+++ b/breathing_cat/resources/sphinx/index.rst.in
@@ -1,6 +1,7 @@
 @HEADER@
 
-.. mdinclude:: readme.md
+.. include:: readme.md
+   :parser: myst_parser.sphinx_
 
 @GENERAL_DOCUMENTATION@
 

--- a/breathing_cat/resources/sphinx/index.rst.in
+++ b/breathing_cat/resources/sphinx/index.rst.in
@@ -1,7 +1,6 @@
 @HEADER@
 
-.. include:: readme.md
-   :parser: myst_parser.sphinx_
+@README@
 
 @GENERAL_DOCUMENTATION@
 
@@ -17,7 +16,4 @@ Indices and Tables
 * :ref:`genindex`
 * :ref:`search`
 
-License and Copyrights
-----------------------
-
-.. include:: license.txt
+@LICENSE@

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ license = {file = "LICENSE"}
 
 dependencies = [
     "breathe",
-    "m2r",
-    "mistune<2.0.0",
     "myst-parser",
     "sphinx",
     "sphinx-rtd-theme",


### PR DESCRIPTION
## Description
We can use MyST to include the README.md into a rst file, thus getting rid of the dependency on m2r (which provides `mdinclude` that was used before).

As this makes different include commands necessary, depending on the format of the README ("md" or "rst"), move the code for handling the README to its own function and generate the appropriate include directive there.  This is then added to index.rst using a template variable.

Apply equivalent changes for including the license file.  Since the license is always expected to be plain text, no format distinction is needed here.  Simply using standard `.. include::` instead of `.. mdinclude::` results in the same output, at least for our BSD license files.

Note that there is a minor difference to using m2r, the section headers of the included README are one level lower now (left is with m2r, right with MyST):
![breathing_cat_Screenshot_20221005_110838_compare_mdinclude_to_myst_include_markdown](https://user-images.githubusercontent.com/9333121/194035269-307d75b0-cdca-480e-93de-33940fd97ca4.png)
However, I don't think this is a problem.  Apart from this the result looks exactly the same.

Closes #2.

## How I Tested

By building the documentation for blmc_drivers (which has a README.md) and robot_fingers (which has README.rst).



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
