### PR TITLE
Allow plain text READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for plain text READMEs ("README" or "README.TXT").
 - Try to auto-detect package version if not explicitly specified.
 - Install executable `bcat`.
 - Short arguments `-p`/`-o` for `--package-dir`/`--output-dir`.
 
 ### Changed
+- If multiple READMEs are found, do not prefer a specific type but simply use the first
+  one found.
 - Renamed `--project-version` to `--package-version`.
 - Use MyST parser instead of recommonmark and m2r for including Markdown files.
 


### PR DESCRIPTION
## Description

Also check for "readme" and "readme.txt" (case insensitive).  If one of these is found, include it with `:literal:`.

If multiple README files are found, simply use the first one found and print a warning.  Normally a package should not have multiple READMEs so if this is the case it should better be fixed by the user.

Closes #7.

## How I Tested

By building documentation of a local package and rename the README to cover the different cases.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
