### PR TITLE
Add DOXYGEN_EXCLUDE_PATTERNS via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try to auto-detect package version if not explicitly specified.
 - Install executable `bcat`.
 - Short arguments `-p`/`-o` for `--package-dir`/`--output-dir`.
+- Provide additional configuration via `breathing_cat.toml`
+- Add `DOXYGEN_EXCLUDE_PATTERNS` via config file.
 
 ### Changed
 - If multiple READMEs are found, do not prefer a specific type but simply use the first

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ For a complete list of options see `bcat --help`.
 Instead of the `bcat` executable, you can also use `python -m breathing_cat`.
 
 
+Configuration
+-------------
+
+A package can contain an optional config file `breathing_cat.toml` which has to be
+placed either in the root directory of the package or in `doc[s]/`.
+
+Below is an exemplary config file, including all available options with their default
+values:
+
+```toml
+[doxygen]
+# List of patterns added to DOXYGEN_EXCLUDE_PATTERNS (see doxygen documentation).
+# The string '${PACKAGE_DIR}' in the patterns is replaced with the path to the package.
+# It is recommended to put this at the beginning of patterns to avoid unintended matches
+# on higher up parts on the path, which would result in *all* the files of the package
+# being excluded.
+# Example:
+# exclude_patterns = ["${PACKAGE_DIR}/include/some_third_party_lib/*"]
+exclude_patterns = []
+```
+
 
 Assumptions Regarding Package Structure
 ---------------------------------------

--- a/breathing_cat/__main__.py
+++ b/breathing_cat/__main__.py
@@ -23,6 +23,7 @@ def main() -> int:
         "-o",
         required=True,
         type=AbsolutePath,
+        metavar="DIRECTORY",
         help="Build directory",
     )
     parser.add_argument(
@@ -30,11 +31,13 @@ def main() -> int:
         "-p",
         required=True,
         type=AbsolutePath,
+        metavar="DIRECTORY",
         help="Package directory",
     )
     parser.add_argument(
         "--python-dir",
         type=AbsolutePath,
+        metavar="DIRECTORY",
         help="""Directory containing the Python package.  If not set, it is
             auto-detected inside the package directory
         """,
@@ -52,6 +55,14 @@ def main() -> int:
         "-f",
         action="store_true",
         help="Do not ask before deleting files.",
+    )
+    parser.add_argument(
+        "--config",
+        type=AbsolutePath,
+        metavar="FILE",
+        help="""Path to config file.  If not set explicitly, bcat searches for a file
+            'breathing_cat.toml' in the package directory.
+        """,
     )
     parser.add_argument("--verbose", action="store_true", help="Enable debug output.")
     args = parser.parse_args()
@@ -88,6 +99,7 @@ def main() -> int:
         args.package_dir,
         args.package_version,
         python_pkg_path=args.python_dir,
+        config_file=args.config,
     )
 
     return 0

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -13,6 +13,8 @@ import textwrap
 import typing
 from pathlib import Path
 
+from . import config as _config
+
 
 PathLike = typing.Union[str, os.PathLike]
 FileFormat = typing.Literal["md", "rst", "txt"]
@@ -568,12 +570,19 @@ def build_documentation(
     project_source_dir: PathLike,
     project_version: str,
     python_pkg_path: typing.Optional[PathLike] = None,
+    config_file: typing.Optional[PathLike] = None,
 ) -> None:
     # make sure all paths are of type Path
     doc_build_dir = Path(build_dir)
     project_source_dir = Path(project_source_dir)
     if python_pkg_path is not None:
         python_pkg_path = Path(python_pkg_path)
+
+    # use default config in none is given
+    if config_file is not None:
+        config = _config.load_config(config_file)
+    else:
+        config = _config.find_and_load_config(project_source_dir)
 
     #
     # Initialize the paths

--- a/breathing_cat/config.py
+++ b/breathing_cat/config.py
@@ -1,0 +1,107 @@
+import collections.abc
+import copy
+import os
+import pathlib
+import typing
+
+import tomli
+
+
+PathLike = typing.Union[str, os.PathLike]
+
+
+_CONFIG_FILE_NAME = "breathing_cat.toml"
+
+_DEFAULT_CONFIG: typing.Dict[str, typing.Any] = {
+    "doxygen": {
+        "exclude_patterns": [],
+    },
+}
+
+
+def update_recursive(d, u):
+    """Recursively update values in d with values from u."""
+    # From https://stackoverflow.com/a/3233356/2095383 (CC BY-SA 4.0)
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = update_recursive(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
+def find_config_file(
+    package_dir: PathLike,
+) -> pathlib.Path:
+    """Find config file in the given package directory.
+
+    Searches for a config file in the following places (in this order):
+
+    - <package_dir>/breathing_cat.toml
+    - <package_dir>/doc/breathing_cat.toml
+    - <package_dir>/docs/breathing_cat.toml
+
+    The first file found is returned.
+
+    Args:
+        package_dir: Directory in which to search for the file.
+
+    Returns:
+        Path to the first config file that was found.
+
+    Raises:
+        FileNotFoundError: If no config file is found.
+    """
+    package_dir = pathlib.Path(package_dir)
+    search_paths = (".", "doc", "docs")
+
+    for search_path in search_paths:
+        path = package_dir / search_path / _CONFIG_FILE_NAME
+        if path.is_file():
+            return path
+
+    concat_paths = ",".join(search_paths)
+    raise FileNotFoundError(
+        f"No file {_CONFIG_FILE_NAME} found in {package_dir}/{{{concat_paths}}}"
+    )
+
+
+def load_config(config_file: PathLike) -> dict:
+    """Load configuration from the given TOML file.
+
+    Load the configuration from the given TOML file (using default values for parameters
+    not specified in the file).
+
+    Args:
+        config_file: Path to the config file.
+
+    Returns:
+        Configuration dictionary.
+    """
+    config = copy.deepcopy(_DEFAULT_CONFIG)
+
+    with open(config_file, "rb") as f:
+        user_config = tomli.load(f)
+    config = update_recursive(config, user_config)
+
+    return config
+
+
+def find_and_load_config(package_dir: PathLike) -> dict:
+    """Find and load config file.  If none is found, return default config.
+
+    See :func:`find_config_file` for possible file locations that are checked.
+
+    Args:
+        package_dir: Directory in which to search for the config file.
+
+    Returns:
+        Configuration.
+    """
+    try:
+        config_file = find_config_file(package_dir)
+        config = load_config(config_file)
+        return config
+    except FileNotFoundError:
+        # if config file is not found, simply return the default config
+        return copy.deepcopy(_DEFAULT_CONFIG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "sphinx",
     "sphinx-rtd-theme",
     "sphinxcontrib-moderncmakedomain",
+    "tomli",
 ]
 
 

--- a/tests/config/config1.toml
+++ b/tests/config/config1.toml
@@ -1,0 +1,2 @@
+[doxygen]
+exclude_patterns = ["config1"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,100 @@
+import pathlib
+import shutil
+from copy import deepcopy
+
+import pytest
+
+from breathing_cat import config
+
+
+@pytest.fixture
+def test_data():
+    return pathlib.Path(__file__).parent / "config"
+
+
+def test_update_recursive():
+    """Test various cases of ``update_recursive``."""
+    d1 = {
+        "foo": 42,
+        "bar": {"one": 1, "two": 2},
+    }
+    u1 = {
+        "foo": 13,
+        "bar": {"two": 3},
+    }
+    u2 = {
+        "bar": {"three": 3},
+        "baz": 23,
+    }
+
+    # Note: first argument is updated in place, so pass copies here
+    assert config.update_recursive(deepcopy(d1), {}) == d1
+    assert config.update_recursive({}, d1) == d1
+    assert config.update_recursive(deepcopy(d1), u1) == {
+        "foo": 13,
+        "bar": {"one": 1, "two": 3},
+    }
+    assert config.update_recursive(deepcopy(d1), u2) == {
+        "foo": 42,
+        "bar": {"one": 1, "two": 2, "three": 3},
+        "baz": 23,
+    }
+
+
+def test_find_config_file_at_root(tmp_path: pathlib.Path):
+    """Test find_config_file with config file at root of search directory."""
+    cfg_file = tmp_path / config._CONFIG_FILE_NAME
+    cfg_file.touch()
+
+    found_file = config.find_config_file(tmp_path)
+    assert found_file == cfg_file
+
+
+def test_find_config_file_in_doc(tmp_path: pathlib.Path):
+    """Test find_config_file with config file in <package>/doc."""
+    path = tmp_path / "doc"
+    cfg_file = path / config._CONFIG_FILE_NAME
+    path.mkdir()
+    cfg_file.touch()
+
+    found_file = config.find_config_file(tmp_path)
+    assert found_file == cfg_file
+
+
+def test_find_config_file_in_docs(tmp_path: pathlib.Path):
+    """Test find_config_file with config file in <package>/docs."""
+    path = tmp_path / "docs"
+    cfg_file = path / config._CONFIG_FILE_NAME
+    path.mkdir()
+    cfg_file.touch()
+
+    found_file = config.find_config_file(tmp_path)
+    assert found_file == cfg_file
+
+
+def test_find_config_file_none(tmp_path: pathlib.Path):
+    """Test find_config_file with no file to be found."""
+    with pytest.raises(FileNotFoundError):
+        config.find_config_file(tmp_path)
+
+
+def test_load_config_not_found():
+    """Test load_config if non-existent file is passed."""
+    with pytest.raises(FileNotFoundError):
+        config.load_config("/does/for/sure/not/exists.toml")
+
+
+def test_load_config(test_data):
+    """Test loading a config file with load_config()."""
+    cfg = config.load_config(test_data / "config1.toml")
+    assert cfg["doxygen"]["exclude_patterns"][0] == "config1"
+
+
+def test_find_and_load_config(tmp_path, test_data):
+    """Test finding and loading a config file."""
+    # copy test config to tmp_path
+    cfg_file = test_data / "config1.toml"
+    shutil.copyfile(cfg_file, tmp_path / config._CONFIG_FILE_NAME)
+
+    cfg = config.find_and_load_config(tmp_path)
+    assert cfg["doxygen"]["exclude_patterns"][0] == "config1"


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add support for a config file `breathing_cat.toml` (either at the root of the package or in `doc[s]/`).  Use this file to allow the user to specify additional patterns for `DOXYGEN_EXCLUDE_PATTERNS` (to exclude some files from the C++ API documentation).

This functionality is needed such that breathing cat can replace the current cmake-based documentation build in mpi_cmake_modules.

Resolves #13.

## How I Tested

By running it on trifinger_object_tracking, which includes a third-party library that should be excluded.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
