### PR TITLE
Add intersphinx config to breathing_cat.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Short arguments `-p`/`-o` for `--package-dir`/`--output-dir`.
 - Provide additional configuration via `breathing_cat.toml`
 - Add `DOXYGEN_EXCLUDE_PATTERNS` via config file.
+- Add intersphinx mappings via config file.
 
 ### Changed
 - If multiple READMEs are found, do not prefer a specific type but simply use the first

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ values:
 # Example:
 # exclude_patterns = ["${PACKAGE_DIR}/include/some_third_party_lib/*"]
 exclude_patterns = []
+
+
+[intersphinx.mapping]
+# Add intersphinx mappings.  See intersphinx documentation for the meaning of the
+# values.
+# Two notations are supported:
+#
+# 1. Long notation (results in `'foo': ('docs.foo.org', 'my_inv.txt'):
+# foo = {target = "docs.foo.org", inventory = "my_inv.txt"}
+#
+# 2. # Short notation (results in `'foo': ('docs.foo.org', None):
+# foo = "docs.foo.org"
 ```
 
 

--- a/breathing_cat/config.py
+++ b/breathing_cat/config.py
@@ -16,6 +16,7 @@ _DEFAULT_CONFIG: typing.Dict[str, typing.Any] = {
     "doxygen": {
         "exclude_patterns": [],
     },
+    "intersphinx": {"mapping": {}},
 }
 
 

--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -136,11 +136,7 @@ html_css_files = [
 
 # -- Options for intersphinx extension ---------------------------------------
 
-# TODO intersphinx doesn't make sense like this.  Either packages need some way to add
-# their own configuration or we should remove it.
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = @INTERSPHINX_MAPPING@
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,32 @@
+import pytest
+
+from breathing_cat import build
+
+
+def test_construct_intersphinx_mapping_config():
+    # empty:
+    assert build._construct_intersphinx_mapping_config({}) == "{}"
+
+    # single
+    cfg = build._construct_intersphinx_mapping_config({"foo": "https://foo.bar"})
+    assert cfg == "{'foo': ('https://foo.bar', None)}"
+
+    # multi
+    cfg = build._construct_intersphinx_mapping_config(
+        {"foo": "https://foo.bar", "bar": {"target": "bar.com", "inventory": "bar.inv"}}
+    )
+    assert cfg == "{'foo': ('https://foo.bar', None), 'bar': ('bar.com', 'bar.inv')}"
+
+    # type checks
+    with pytest.raises(AssertionError):
+        build._construct_intersphinx_mapping_config({42: "foo"})
+    with pytest.raises(AssertionError):
+        build._construct_intersphinx_mapping_config({"foo": 42})
+    with pytest.raises(AssertionError):
+        build._construct_intersphinx_mapping_config(
+            {"foo": {"target": 13, "inventory": "inv"}}
+        )
+    with pytest.raises(AssertionError):
+        build._construct_intersphinx_mapping_config(
+            {"foo": {"target": "url", "inventory": 42}}
+        )


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Set `intersphinx_mapping` based on configuration given in `breathing_cat.toml`.  This way packages can add their required mappings and thus actually use intersphinx.

Resolves #10.

## How I Tested

- Through the added unit tests.
- By adding intersphinx config to a package and using it there.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
