### PR TITLE
pyproject: Dynamically load version from __init__.py

### DIFF
--- a/breathing_cat/__init__.py
+++ b/breathing_cat/__init__.py
@@ -1,3 +1,1 @@
-import importlib.metadata
-
-__version__ = importlib.metadata.version(__package__)
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "breathing_cat"
-version = "0.1.0"
 description = "Tool to build documentation for C++/Python-Packages used at MPI-IS"
 authors = [
     {name = "Maximilien Naveau"},
@@ -16,6 +15,7 @@ maintainers = [
 ]
 readme = "README.md"
 license = {file = "LICENSE"}
+dynamic = ["version"]
 
 dependencies = [
     "breathe",
@@ -34,3 +34,6 @@ bcat = "breathing_cat.__main__:main"
 
 [tool.setuptools.package-data]
 breathing_cat = ["resources/**/*.in"]
+
+[tool.setuptools.dynamic]
+version = {attr = "breathing_cat.__version__"}


### PR DESCRIPTION

## Description

Use the `attr` feature of setuptools to load the version from the __init__.py file.
This removes the need for importlib, which is not yet available in Python 3.7.



## How I Tested

Through this PR (see the Python 3.7 test).

