### PR TITLE
Set minimal Python version to 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.8", "3.9", "3.10"]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,14 @@ maintainers = [
 ]
 readme = "README.md"
 license = {file = "LICENSE"}
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
 
+requires-python = ">=3.8"
 dependencies = [
     "breathe",
     "myst-parser",


### PR DESCRIPTION
## Description

The package uses features that are only supported in Python >=3.8, so set this as minimum version.

## How I Tested

Through the tests here on Github.