### PR TITLE
Extend metadata and documentation for first release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
+dist/
 venv/
 *.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [1.0.0] - 2022-10-21
 ### Added
 - Support for plain text READMEs ("README" or "README.TXT").
 - Try to auto-detect package version if not explicitly specified.
@@ -25,7 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caused class properties to be floating (see
   https://github.com/readthedocs/sphinx_rtd_theme/issues/1247)
 
+
 ## [0.1.0] - 2022-09-08
 Extracted the documentation build code from
 [mpi_cmake_modules](https://github.com/machines-in-motion/mpi_cmake_modules) with only
 some minor changes. 
+
+
+[Unreleased]: https://github.com/machines-in-motion/breathing-cat/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/machines-in-motion/breathing-cat/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/machines-in-motion/breathing-cat/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Documentation Builder for C++ and Python packages
 =================================================
 
-breathing_cat is a tool for building documentation that is used for some of the
+Breathing Cat is a tool for building documentation that is used for some of the
 software packages developed at the Max Planck Institute for Intelligent Systems (MPI-IS)
 and the New York University.
 
@@ -17,15 +17,17 @@ assumptions we make regarding the package structure).
 Installation
 ------------
 
-Simply clone this repository and install it with
-
+Breathing Cat depends on [Doxygen](https://doxygen.nl) for generating C++ documentation.
+As Doxygen cannot automatically be installed as dependency by pip, it needs to be
+installed manually.  For example on Ubuntu:
 ```
-cd path/to/breathing-cat
-pip install .
+sudo apt install doxygen
 ```
 
-Note that for building C++ API documentation Doxygen is used, which needs to be
-installed separately (e.g. with `sudo apt install doxygen` on Ubuntu).
+To install Breathing Cat with all further dependencies:
+```
+pip install breathing_cat
+```
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -91,7 +91,31 @@ exclude_patterns = []
 Assumptions Regarding Package Structure
 ---------------------------------------
 
-TODO
+Breathing Cat makes the following assumptions regarding the structure of the documented
+package:
+
+- The directory containing the package has the same name as the actual package.
+- The package may contain a README file that has one of the following names (case
+  insensitive):  `README`, `README.txt`, `README.md`, `README.rst`
+- The package may contain a license file called `LICENSE` or `license.txt`.
+- C++ code is documented using Doxygen comments in the header files.
+- C++ header files are located outside of `src/` (typically in `include/`).
+- Python code is documented using docstrings (supported formats are standard Sphinx,
+  NumPy Style and Google Style).
+- The Python code is located in one of the following directories (relative to the
+  package root):
+
+  - `<package_name>/`
+  - `python/<package_name>/`
+  - `src/<package_name>/`
+
+- CMake files that should be documented are located in `cmake/` and use the directives
+  provided by the
+  [sphinxcontrib.moderncmakedomain](https://github.com/scikit-build/moderncmakedomain)
+  extension.
+- General documentation is provided in reStructuredText- or Markdown-files located in
+  `doc/` or `docs/`.  All files found in this directory are automatically included in
+  alphabetical order.
 
 
 Copyright & License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "breathing_cat"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Tool to build documentation for C++/Python-Packages used at MPI-IS"
 authors = [
     {name = "Maximilien Naveau"},
@@ -15,12 +15,15 @@ maintainers = [
     {name = "Felix Widmaier", email = "felix.widmaier@tuebingen.mpg.de"}
 ]
 readme = "README.md"
-license = {file = "LICENSE"}
+keywords = ["documentation", "sphinx", "doxygen"]
 classifiers = [
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Topic :: Documentation",
+    "Topic :: Documentation :: Sphinx",
 ]
 
 requires-python = ">=3.8"
@@ -32,6 +35,10 @@ dependencies = [
     "sphinxcontrib-moderncmakedomain",
     "tomli",
 ]
+
+[project.urls]
+"Source Code" = "https://github.com/machines-in-motion/breathing-cat"
+"Bug Tracker" = "https://github.com/machines-in-motion/breathing-cat/issues"
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "breathing_cat"
-version = "1.0.0rc1"
+version = "1.0.0"
 description = "Tool to build documentation for C++/Python-Packages used at MPI-IS"
 authors = [
     {name = "Maximilien Naveau"},


### PR DESCRIPTION
## Description

Finalises a few things to prepare for the release of 1.0.0:

- Bump version to 1.0.0.
- Add documentation on expected package structure (closes #4).
- Update installation instructions (already assuming the Package is on PyPI).
- Add more metadata in pyproject.toml.
- Update CHANGELOG


## How I Tested

Through this PR (unittests) and by running it locally to build documentation of a package.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
