### PR TITLE
Use variconf to find and load config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Deprecated
+- Using `${PACKAGE_DIR}` in Doxygen exclude patterns is deprecated, use the new syntax
+  `{{PACKAGE_DIR}}` instead.
 
 
 ## [1.0.0] - 2022-10-21

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ values:
 ```toml
 [doxygen]
 # List of patterns added to DOXYGEN_EXCLUDE_PATTERNS (see doxygen documentation).
-# The string '${PACKAGE_DIR}' in the patterns is replaced with the path to the package.
+# The string '{{PACKAGE_DIR}}' in the patterns is replaced with the path to the package.
 # It is recommended to put this at the beginning of patterns to avoid unintended matches
 # on higher up parts on the path, which would result in *all* the files of the package
 # being excluded.
 # Example:
-# exclude_patterns = ["${PACKAGE_DIR}/include/some_third_party_lib/*"]
+# exclude_patterns = ["{{PACKAGE_DIR}}/include/some_third_party_lib/*"]
 exclude_patterns = []
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "sphinx",
     "sphinx-rtd-theme",
     "sphinxcontrib-moderncmakedomain",
-    "tomli",
+    "variconf[toml]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

Using [variconf](https://github.com/MPI-IS/variconf) makes loading the config file much easier, as we don't have to reinvent the wheel for handling default values, finding the file, etc.

Unfortunately, the current syntax of using `${PACKAGE_DIR}` in Doxygen exclude patterns collides with OmegaConf's variable interpolation feature.  Therefore, change the syntax in the exclude patterns to `{{PACKAGE_DIR}}`.

Using `${PACKAGE_DIR}` is now deprecated but currently still supported via a little hack: Adding 

    "PACKAGE_DIR": "{{PACKAGE_DIR}}"

to the default configuration let's OmegaConf replace `${PACKAGE_DIR}` with `{{PACKAGE_DIR}}` when loading the file.  This avoids a breaking change for now but should probably be removed in the next major release.

I also moved the code for constructing the EXCLUDE_PATTERNS string into its own function, so it could add unit tests.


## How I Tested

Through the unit tests and by building documentation of trifinger_object_tracking.


## Do not merge before

- [x] This currently breaks the usage of `${PACKAGE_DIR}` in the exclude patterns of the config file (collides with the variable interpolation feature of OmegaConf...). TODO: Add test that covers this issue.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
