### PR TITLE
Fix intersphinx config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fixed issue with configuration validation that rejected valid intersphinx mapping
+  configuration.
 
 ## [1.1.0] - 2022-11-04
 ### Changed

--- a/breathing_cat/config.py
+++ b/breathing_cat/config.py
@@ -22,7 +22,7 @@ _DEFAULT_CONFIG: typing.Dict[str, typing.Any] = {
 
 def config_from_dict(config: dict) -> dict:
     """Get the default configuration."""
-    config_loader = variconf.WConf(_DEFAULT_CONFIG)
+    config_loader = variconf.WConf(_DEFAULT_CONFIG, strict=False)
     config_loader.load_dict(config)
 
     return typing.cast(dict, OmegaConf.to_container(config_loader.get(), resolve=True))
@@ -40,7 +40,7 @@ def load_config(config_file: PathLike) -> dict:
     Returns:
         Configuration.
     """
-    config_loader = variconf.WConf(_DEFAULT_CONFIG)
+    config_loader = variconf.WConf(_DEFAULT_CONFIG, strict=False)
     config_loader.load_file(config_file)
 
     return typing.cast(dict, OmegaConf.to_container(config_loader.get(), resolve=True))
@@ -63,7 +63,7 @@ def find_and_load_config(
     package_dir = pathlib.PurePath(package_dir)
     search_paths = [package_dir, package_dir / "doc", package_dir / "docs"]
 
-    config_loader = variconf.WConf(_DEFAULT_CONFIG)
+    config_loader = variconf.WConf(_DEFAULT_CONFIG, strict=False)
     config_loader.load_file(
         config_file_name, search_paths=search_paths, fail_if_not_found=False
     )

--- a/breathing_cat/config.py
+++ b/breathing_cat/config.py
@@ -46,13 +46,16 @@ def load_config(config_file: PathLike) -> dict:
     return typing.cast(dict, OmegaConf.to_container(config_loader.get(), resolve=True))
 
 
-def find_and_load_config(package_dir: PathLike) -> dict:
+def find_and_load_config(
+    package_dir: PathLike, config_file_name: str = _CONFIG_FILE_NAME
+) -> dict:
     """Find and load config file.  If none is found, return default config.
 
     See :func:`find_config_file` for possible file locations that are checked.
 
     Args:
         package_dir: Directory in which to search for the config file.
+        config_file_name: Name of the file to search for.
 
     Returns:
         Configuration.
@@ -62,7 +65,7 @@ def find_and_load_config(package_dir: PathLike) -> dict:
 
     config_loader = variconf.WConf(_DEFAULT_CONFIG)
     config_loader.load_file(
-        _CONFIG_FILE_NAME, search_paths=search_paths, fail_if_not_found=False
+        config_file_name, search_paths=search_paths, fail_if_not_found=False
     )
 
     return typing.cast(dict, OmegaConf.to_container(config_loader.get(), resolve=True))

--- a/breathing_cat/config.py
+++ b/breathing_cat/config.py
@@ -20,9 +20,13 @@ _DEFAULT_CONFIG: typing.Dict[str, typing.Any] = {
 }
 
 
+def _get_config_loader() -> variconf.WConf:
+    return variconf.WConf(_DEFAULT_CONFIG, strict=False)
+
+
 def config_from_dict(config: dict) -> dict:
     """Get the default configuration."""
-    config_loader = variconf.WConf(_DEFAULT_CONFIG, strict=False)
+    config_loader = _get_config_loader()
     config_loader.load_dict(config)
 
     return typing.cast(dict, OmegaConf.to_container(config_loader.get(), resolve=True))
@@ -40,7 +44,7 @@ def load_config(config_file: PathLike) -> dict:
     Returns:
         Configuration.
     """
-    config_loader = variconf.WConf(_DEFAULT_CONFIG, strict=False)
+    config_loader = _get_config_loader()
     config_loader.load_file(config_file)
 
     return typing.cast(dict, OmegaConf.to_container(config_loader.get(), resolve=True))
@@ -63,7 +67,7 @@ def find_and_load_config(
     package_dir = pathlib.PurePath(package_dir)
     search_paths = [package_dir, package_dir / "doc", package_dir / "docs"]
 
-    config_loader = variconf.WConf(_DEFAULT_CONFIG, strict=False)
+    config_loader = _get_config_loader()
     config_loader.load_file(
         config_file_name, search_paths=search_paths, fail_if_not_found=False
     )

--- a/tests/config/config_intersphinx.toml
+++ b/tests/config/config_intersphinx.toml
@@ -1,0 +1,3 @@
+[intersphinx.mapping]
+long = {target = "docs.foo.org", inventory = "my_inv.txt"}
+short = "docs.foo.org"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,42 @@ def test_load_config(test_data):
     assert cfg["doxygen"]["exclude_patterns"][0] == "config1"
 
 
+def test_config_from_dict_intersphinx(test_data):
+    """Test loading a config file with load_config()."""
+    cfg = config.config_from_dict(
+        {
+            "intersphinx": {
+                "mapping": {
+                    "long": {"target": "docs.foo.org", "inventory": "my_inv.txt"},
+                    "short": "docs.foo.org",
+                }
+            },
+        }
+    )
+    assert cfg["intersphinx"]["mapping"] == {
+        "long": {"target": "docs.foo.org", "inventory": "my_inv.txt"},
+        "short": "docs.foo.org",
+    }
+
+
+def test_load_config_intersphinx(test_data):
+    """Test loading a config file with load_config()."""
+    cfg = config.load_config(test_data / "config_intersphinx.toml")
+    assert cfg["intersphinx"]["mapping"] == {
+        "long": {"target": "docs.foo.org", "inventory": "my_inv.txt"},
+        "short": "docs.foo.org",
+    }
+
+
+def test_find_and_load_config_intersphinx(test_data):
+    """Test loading a config file with load_config()."""
+    cfg = config.find_and_load_config(test_data, "config_intersphinx.toml")
+    assert cfg["intersphinx"]["mapping"] == {
+        "long": {"target": "docs.foo.org", "inventory": "my_inv.txt"},
+        "short": "docs.foo.org",
+    }
+
+
 def _setup_pkg_dir_with_config(config_location, tmp_path, test_data):
     """Helper for the test_find_and_load_config_* functions."""
     # create target directory


### PR DESCRIPTION
## Description

The recent change to using variconf with strict config schema broke the intersphinx mapping configuration (as using an dictionary as value was adding new, unexpected keys to the config).
Unfortunately, I couldn't find a way to make the current config (which accepts either a string or a dictionary for the the individual entries) work with OmegaConf as union types are not fully supported (this may change with the next bigger release of OmegaConf, though).

As a workaround for now, simply make the config non-strict.

I also added unit tests to cover this case.


## How I Tested

Through the unit tests and by building docs for robot_fingers which uses intersphinx.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
