### PR TITLE
Use index.rst in package root as alternative to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- If the package root contains a file `index.rst`, it is used instead of the README to
-  fill the main page.  This is useful if the content of the README is not suitable for
-  the documentation main page.
+- If the package root contains a file `doc_mainpage.rst`, it is used instead of the
+  README to fill the main page.  This is useful if the content of the README is not
+  suitable for the documentation main page.
 
 ## [1.1.1] - 2022-11-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- If the package root contains a file `doc_mainpage.rst`, it is used instead of the
+- If the package root contains a file `doc_mainpage.{rst,md}`, it is used instead of the
   README to fill the main page.  This is useful if the content of the README is not
   suitable for the documentation main page.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- If the package root contains a file `index.rst`, it is used instead of the README to
+  fill the main page.  This is useful if the content of the README is not suitable for
+  the documentation main page.
 
 ## [1.1.1] - 2022-11-11
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,8 +97,17 @@ Breathing Cat makes the following assumptions regarding the structure of the doc
 package:
 
 - The directory containing the package has the same name as the actual package.
-- The package may contain a README file that has one of the following names (case
-  insensitive):  `README`, `README.txt`, `README.md`, `README.rst`
+- If the package contains one of the following files (case insensitive) in the root
+  directory, it is included into the documentations main page:
+  ```
+  index.rst, README.rst, README.md, README.txt, README
+  ```
+  If there are multiple matches, only the first one is used with precedence based on the
+  list above.
+
+  The idea of having `index.rst` at the first place is, that it can be provided in
+  addition to a README.  This is useful if the content of the README is not suitable for
+  the documentation main page.
 - The package may contain a license file called `LICENSE` or `license.txt`.
 - C++ code is documented using Doxygen comments in the header files.
 - C++ header files are located outside of `src/` (typically in `include/`).

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ package:
 - If the package contains one of the following files (case insensitive) in the root
   directory, it is included into the documentations main page:
   ```
-  index.rst, README.rst, README.md, README.txt, README
+  doc_mainpage.rst, README.rst, README.md, README.txt, README
   ```
   If there are multiple matches, only the first one is used with precedence based on the
   list above.
 
-  The idea of having `index.rst` at the first place is, that it can be provided in
-  addition to a README.  This is useful if the content of the README is not suitable for
-  the documentation main page.
+  Since `doc_mainpage.rst` has highest precedence, it can be provided in addition to a
+  README.  This is useful if you want to have different content in the README and on the
+  documentation main page.
 - The package may contain a license file called `LICENSE` or `license.txt`.
 - C++ code is documented using Doxygen comments in the header files.
 - C++ header files are located outside of `src/` (typically in `include/`).

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ package:
 - If the package contains one of the following files (case insensitive) in the root
   directory, it is included into the documentations main page:
   ```
-  doc_mainpage.rst, README.rst, README.md, README.txt, README
+  doc_mainpage.rst, doc_mainpage.md, README.rst, README.md, README.txt, README
   ```
   If there are multiple matches, only the first one is used with precedence based on the
   list above.
 
-  Since `doc_mainpage.rst` has highest precedence, it can be provided in addition to a
-  README.  This is useful if you want to have different content in the README and on the
-  documentation main page.
+  Since `doc_mainpage.{rst,md}` has highest precedence, it can be provided in addition
+  to a README.  This is useful if you want to have different content in the README and
+  on the documentation main page.
 - The package may contain a license file called `LICENSE` or `license.txt`.
 - C++ code is documented using Doxygen comments in the header files.
 - C++ header files are located outside of `src/` (typically in `include/`).

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -596,7 +596,7 @@ def _search_for_license(project_source_dir: Path, doc_build_dir: Path) -> str:
         license_include = textwrap.dedent(
             """
             License and Copyrights
-            ----------------------
+            ======================
 
             .. include:: license.txt
         """
@@ -731,8 +731,10 @@ def build_documentation(
     )
 
     # configure the index.rst.in.
-    header = "Welcome to " + project_name + "'s documentation!"
-    header += "\n" + len(header) * "=" + "\n"
+    header = f"Welcome to {project_name}'s documentation!"
+    header_line = "*" * len(header)
+    header = f"{header_line}\n{header}\n{header_line}"
+
     with open(resource_dir / "sphinx" / "index.rst.in", "rt") as f:
         out_text = (
             f.read()

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -476,7 +476,9 @@ def _search_for_general_documentation(
     return general_documentation
 
 
-def _copy_mainpage(source_dir: Path, destination_dir: Path) -> FileFormat:
+def _copy_mainpage(
+    source_dir: Path, destination_dir: Path
+) -> typing.Tuple[str, FileFormat]:
     """Searches for a doc_mainpage.rst or README in the source and copies it to the
     destination directory.
 
@@ -492,7 +494,7 @@ def _copy_mainpage(source_dir: Path, destination_dir: Path) -> FileFormat:
         destination_dir: Directory to which the README is copied.
 
     Returns:
-        Format of the README file.
+        Tuple with filename in destination_dir and format of the file ("rst", "md",...).
 
     Raises
         FileNotFoundError: If no README is found in the source directory.
@@ -519,10 +521,10 @@ def _copy_mainpage(source_dir: Path, destination_dir: Path) -> FileFormat:
 
     readme = find_matching_file()
     readme_format = options[readme.name.lower()]
-    target_filename = f"readme.{readme_format}"
+    target_filename = f"mainpage.{readme_format}"
     shutil.copy(readme, destination_dir / target_filename)
 
-    return readme_format
+    return target_filename, readme_format
 
 
 def _copy_license(source_dir: Path, destination_dir: Path) -> None:
@@ -547,7 +549,8 @@ def _copy_license(source_dir: Path, destination_dir: Path) -> None:
 
 
 def _search_for_mainpage(project_source_dir: Path, doc_build_dir: Path) -> str:
-    """Copy doc_mainpage/README file to build directory and return RST code to include it.
+    """
+    Copy doc_mainpage/README file to build directory and return RST code to include it.
 
     Args:
         project_source_dir: Where to look for the file.
@@ -558,28 +561,28 @@ def _search_for_mainpage(project_source_dir: Path, doc_build_dir: Path) -> str:
         string is return.
     """
     try:
-        readme_format = _copy_mainpage(project_source_dir, doc_build_dir)
+        mainpage, mainpage_format = _copy_mainpage(project_source_dir, doc_build_dir)
         # the include command differs depending on the format of the README
-        if readme_format == "md":
-            readme_include = textwrap.dedent(
-                """
-                .. include:: readme.md
+        if mainpage_format == "md":
+            mainpage_include = textwrap.dedent(
+                f"""
+                .. include:: {mainpage}
                    :parser: myst_parser.sphinx_
             """
             )
-        elif readme_format == "txt":
-            readme_include = textwrap.dedent(
-                """
-                .. include:: readme.txt
+        elif mainpage_format == "txt":
+            mainpage_include = textwrap.dedent(
+                f"""
+                .. include:: {mainpage}
                    :literal:
             """
             )
         else:
-            readme_include = ".. include:: readme.rst"
+            mainpage_include = f".. include:: {mainpage}"
     except FileNotFoundError:
-        readme_include = ""
+        mainpage_include = ""
 
-    return readme_include
+    return mainpage_include
 
 
 def _search_for_license(project_source_dir: Path, doc_build_dir: Path) -> str:

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -480,7 +480,8 @@ def _copy_mainpage(source_dir: Path, destination_dir: Path) -> FileFormat:
     """Searches for a doc_mainpage.rst or README in the source and copies it to the
     destination directory.
 
-    Searches for [doc_mainpage.rst, readme.rst, readme.md, readme.txt, readme]
+    Searches for
+    [doc_mainpage.rst, doc_mainpage.md, readme.rst, readme.md, readme.txt, readme]
     (case-insensitive) in the source directory and copies the first match to the
     destination directory.
 
@@ -499,6 +500,7 @@ def _copy_mainpage(source_dir: Path, destination_dir: Path) -> FileFormat:
     # map allowed readme file names to file format
     options: typing.Dict[str, FileFormat] = {
         "doc_mainpage.rst": "rst",
+        "doc_mainpage.md": "md",
         "readme.rst": "rst",
         "readme.md": "md",
         "readme": "txt",

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -476,11 +476,11 @@ def _search_for_general_documentation(
     return general_documentation
 
 
-def _copy_index_or_readme(source_dir: Path, destination_dir: Path) -> FileFormat:
-    """Searches for a index.rst or README file in the source and copies it to the
+def _copy_mainpage(source_dir: Path, destination_dir: Path) -> FileFormat:
+    """Searches for a doc_mainpage.rst or README in the source and copies it to the
     destination directory.
 
-    Searches for [index.rst, readme.rst, readme.md, readme.txt, readme]
+    Searches for [doc_mainpage.rst, readme.rst, readme.md, readme.txt, readme]
     (case-insensitive) in the source directory and copies the first match to the
     destination directory.
 
@@ -498,7 +498,7 @@ def _copy_index_or_readme(source_dir: Path, destination_dir: Path) -> FileFormat
     """
     # map allowed readme file names to file format
     options: typing.Dict[str, FileFormat] = {
-        "index.rst": "rst",
+        "doc_mainpage.rst": "rst",
         "readme.rst": "rst",
         "readme.md": "md",
         "readme": "txt",
@@ -513,7 +513,7 @@ def _copy_index_or_readme(source_dir: Path, destination_dir: Path) -> FileFormat
                 if file.name.lower() == candidate:
                     return file.resolve()
 
-        raise FileNotFoundError(f"No README or index file found in {source_dir}")
+        raise FileNotFoundError(f"No mainpage or README file found in {source_dir}")
 
     readme = find_matching_file()
     readme_format = options[readme.name.lower()]
@@ -544,8 +544,8 @@ def _copy_license(source_dir: Path, destination_dir: Path) -> None:
     shutil.copy(license_file[0], destination_dir / "license.txt")
 
 
-def _search_for_index_or_readme(project_source_dir: Path, doc_build_dir: Path) -> str:
-    """Copy index/README file to build directory and return RST code to include it.
+def _search_for_mainpage(project_source_dir: Path, doc_build_dir: Path) -> str:
+    """Copy doc_mainpage/README file to build directory and return RST code to include it.
 
     Args:
         project_source_dir: Where to look for the file.
@@ -556,7 +556,7 @@ def _search_for_index_or_readme(project_source_dir: Path, doc_build_dir: Path) -
         string is return.
     """
     try:
-        readme_format = _copy_index_or_readme(project_source_dir, doc_build_dir)
+        readme_format = _copy_mainpage(project_source_dir, doc_build_dir)
         # the include command differs depending on the format of the README
         if readme_format == "md":
             readme_include = textwrap.dedent(
@@ -718,7 +718,7 @@ def build_documentation(
     #
     # Copy the license and readme file.
     #
-    readme_include = _search_for_index_or_readme(project_source_dir, doc_build_dir)
+    readme_include = _search_for_mainpage(project_source_dir, doc_build_dir)
     license_include = _search_for_license(project_source_dir, doc_build_dir)
 
     #

--- a/breathing_cat/resources/sphinx/index.rst.in
+++ b/breathing_cat/resources/sphinx/index.rst.in
@@ -11,7 +11,7 @@
 @CMAKE_API@
 
 Indices and Tables
-------------------
+==================
 
 * :ref:`genindex`
 * :ref:`search`

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -141,7 +141,7 @@ def test_search_for_general_documentation(ros_pkg_path: Path, tmp_path: Path) ->
     assert "@" not in general_doc_content
 
 
-def _test_copy_readme(tmp_path: Path, filename_in: str, filename_out: str) -> None:
+def _test_copy_mainpage(tmp_path: Path, filename_in: str, filename_out: str) -> None:
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     pkg_dir = tmp_path / "pkg"
@@ -149,7 +149,7 @@ def _test_copy_readme(tmp_path: Path, filename_in: str, filename_out: str) -> No
     readme = pkg_dir / filename_in
     readme.write_text("Hello")
 
-    build._copy_index_or_readme(pkg_dir, build_dir)
+    build._copy_mainpage(pkg_dir, build_dir)
     build_dir_content = [str(f.name) for f in build_dir.iterdir()]
     assert (
         build_dir / filename_out
@@ -157,32 +157,32 @@ def _test_copy_readme(tmp_path: Path, filename_in: str, filename_out: str) -> No
     assert (build_dir / filename_out).read_text() == "Hello"
 
 
-def test_copy_readme(tmp_path: Path) -> None:
-    _test_copy_readme(tmp_path, "README", "readme.txt")
+def test_copy_mainpage_readme(tmp_path: Path) -> None:
+    _test_copy_mainpage(tmp_path, "README", "readme.txt")
 
 
-def test_copy_readme_txt(tmp_path: Path) -> None:
-    _test_copy_readme(tmp_path, "README.TXT", "readme.txt")
+def test_copy_mainpage_readme_txt(tmp_path: Path) -> None:
+    _test_copy_mainpage(tmp_path, "README.TXT", "readme.txt")
 
 
-def test_copy_readme_md(tmp_path: Path) -> None:
-    _test_copy_readme(tmp_path, "README.md", "readme.md")
+def test_copy_mainpage_readme_md(tmp_path: Path) -> None:
+    _test_copy_mainpage(tmp_path, "README.md", "readme.md")
 
 
-def test_copy_readme_rst(tmp_path: Path) -> None:
-    _test_copy_readme(tmp_path, "README.rst", "readme.rst")
+def test_copy_mainpage_readme_rst(tmp_path: Path) -> None:
+    _test_copy_mainpage(tmp_path, "README.rst", "readme.rst")
 
 
-def test_copy_readme_index_rst(tmp_path: Path) -> None:
-    _test_copy_readme(tmp_path, "index.rst", "readme.rst")
+def test_copy_mainpage_doc_mainpage_rst(tmp_path: Path) -> None:
+    _test_copy_mainpage(tmp_path, "doc_mainpage.rst", "readme.rst")
 
 
-def test_copy_readme_not_found(tmp_path: Path) -> None:
+def test_copy_mainpage_not_found(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
-        _test_copy_readme(tmp_path, "wrong_name", "readme.rst")
+        _test_copy_mainpage(tmp_path, "wrong_name", "readme.rst")
 
 
-def test_copy_index_or_readme_precedence(tmp_path: Path) -> None:
+def test_copy_mainpage_precedence(tmp_path: Path) -> None:
     build_dir = tmp_path / "build"
     build_dir.mkdir()
     pkg_dir = tmp_path / "pkg"
@@ -190,15 +190,15 @@ def test_copy_index_or_readme_precedence(tmp_path: Path) -> None:
 
     readme = pkg_dir / "README.rst"
     readme.write_text("This is the README")
-    index_rst = pkg_dir / "index.rst"
-    index_rst.write_text("This is the index.rst")
+    mainpage_rst = pkg_dir / "doc_mainpage.rst"
+    mainpage_rst.write_text("This is the doc_mainpage.rst")
 
-    build._copy_index_or_readme(pkg_dir, build_dir)
+    build._copy_mainpage(pkg_dir, build_dir)
     build_dir_content = [str(f.name) for f in build_dir.iterdir()]
     assert (
         build_dir / "readme.rst"
     ).is_file(), f"readme.rst not found.  build dir content: {build_dir_content}"
-    assert (build_dir / "readme.rst").read_text() == "This is the index.rst"
+    assert (build_dir / "readme.rst").read_text() == "This is the doc_mainpage.rst"
 
 
 def _test_copy_license(tmp_path: Path, filename_in: str, filename_out: str) -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -158,32 +158,32 @@ def _test_copy_mainpage(tmp_path: Path, filename_in: str, filename_out: str) -> 
 
 
 def test_copy_mainpage_readme(tmp_path: Path) -> None:
-    _test_copy_mainpage(tmp_path, "README", "readme.txt")
+    _test_copy_mainpage(tmp_path, "README", "mainpage.txt")
 
 
 def test_copy_mainpage_readme_txt(tmp_path: Path) -> None:
-    _test_copy_mainpage(tmp_path, "README.TXT", "readme.txt")
+    _test_copy_mainpage(tmp_path, "README.TXT", "mainpage.txt")
 
 
 def test_copy_mainpage_readme_md(tmp_path: Path) -> None:
-    _test_copy_mainpage(tmp_path, "README.md", "readme.md")
+    _test_copy_mainpage(tmp_path, "README.md", "mainpage.md")
 
 
 def test_copy_mainpage_readme_rst(tmp_path: Path) -> None:
-    _test_copy_mainpage(tmp_path, "README.rst", "readme.rst")
+    _test_copy_mainpage(tmp_path, "README.rst", "mainpage.rst")
 
 
 def test_copy_mainpage_doc_mainpage_rst(tmp_path: Path) -> None:
-    _test_copy_mainpage(tmp_path, "doc_mainpage.rst", "readme.rst")
+    _test_copy_mainpage(tmp_path, "doc_mainpage.rst", "mainpage.rst")
 
 
 def test_copy_mainpage_doc_mainpage_md(tmp_path: Path) -> None:
-    _test_copy_mainpage(tmp_path, "doc_mainpage.md", "readme.md")
+    _test_copy_mainpage(tmp_path, "doc_mainpage.md", "mainpage.md")
 
 
 def test_copy_mainpage_not_found(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
-        _test_copy_mainpage(tmp_path, "wrong_name", "readme.rst")
+        _test_copy_mainpage(tmp_path, "wrong_name", "mainpage.rst")
 
 
 def test_copy_mainpage_precedence(tmp_path: Path) -> None:
@@ -200,9 +200,9 @@ def test_copy_mainpage_precedence(tmp_path: Path) -> None:
     build._copy_mainpage(pkg_dir, build_dir)
     build_dir_content = [str(f.name) for f in build_dir.iterdir()]
     assert (
-        build_dir / "readme.rst"
-    ).is_file(), f"readme.rst not found.  build dir content: {build_dir_content}"
-    assert (build_dir / "readme.rst").read_text() == "This is the doc_mainpage.rst"
+        build_dir / "mainpage.rst"
+    ).is_file(), f"mainpage.rst not found.  build dir content: {build_dir_content}"
+    assert (build_dir / "mainpage.rst").read_text() == "This is the doc_mainpage.rst"
 
 
 def _test_copy_license(tmp_path: Path, filename_in: str, filename_out: str) -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -149,7 +149,7 @@ def _test_copy_readme(tmp_path: Path, filename_in: str, filename_out: str) -> No
     readme = pkg_dir / filename_in
     readme.write_text("Hello")
 
-    build._copy_readme(pkg_dir, build_dir)
+    build._copy_index_or_readme(pkg_dir, build_dir)
     build_dir_content = [str(f.name) for f in build_dir.iterdir()]
     assert (
         build_dir / filename_out
@@ -173,9 +173,32 @@ def test_copy_readme_rst(tmp_path: Path) -> None:
     _test_copy_readme(tmp_path, "README.rst", "readme.rst")
 
 
+def test_copy_readme_index_rst(tmp_path: Path) -> None:
+    _test_copy_readme(tmp_path, "index.rst", "readme.rst")
+
+
 def test_copy_readme_not_found(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         _test_copy_readme(tmp_path, "wrong_name", "readme.rst")
+
+
+def test_copy_index_or_readme_precedence(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+
+    readme = pkg_dir / "README.rst"
+    readme.write_text("This is the README")
+    index_rst = pkg_dir / "index.rst"
+    index_rst.write_text("This is the index.rst")
+
+    build._copy_index_or_readme(pkg_dir, build_dir)
+    build_dir_content = [str(f.name) for f in build_dir.iterdir()]
+    assert (
+        build_dir / "readme.rst"
+    ).is_file(), f"readme.rst not found.  build dir content: {build_dir_content}"
+    assert (build_dir / "readme.rst").read_text() == "This is the index.rst"
 
 
 def _test_copy_license(tmp_path: Path, filename_in: str, filename_out: str) -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -177,6 +177,10 @@ def test_copy_mainpage_doc_mainpage_rst(tmp_path: Path) -> None:
     _test_copy_mainpage(tmp_path, "doc_mainpage.rst", "readme.rst")
 
 
+def test_copy_mainpage_doc_mainpage_md(tmp_path: Path) -> None:
+    _test_copy_mainpage(tmp_path, "doc_mainpage.md", "readme.md")
+
+
 def test_copy_mainpage_not_found(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         _test_copy_mainpage(tmp_path, "wrong_name", "readme.rst")


### PR DESCRIPTION
## Description

Add "index.rst" as a candidate name for the README file (rename the corresponding functions to "..._index_or_readme" to reflect this).

Rewrite the code search for the file such that in case of multiple matches, the order in which they are specified in `options` is adhered to (previously it was just randomly picking whichever was first returned by `glob("*")`).

It resolves the issue that the content in the README does not always make sense to be used as documentation main page by adding the option to provide an additional index.rst next to the README (GitHub will still show the README but the documentation will use the index.rst).

I would actually prefer to locate the index.rst in the doc/ folder as this seems cleaner. However, this would cause trouble with relative links as in the build dir, the index.rst is outside the doc/ folder.  Thus I decided to put it at the package root, so the relative path from index.rst to other doc files is the same.  This has the nice side effect that it is also much easier to implement, as I basically just needed to extend the README search a bit :)


## How I Tested

Building documentation for a package with and without an `index.rst` next to the README.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
