### PR TITLE
Mark external links in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add config parameter `mainpage.title` to set a custom title.
 - Add config parameter `mainpage.auto_general_docs` to disable automatic creation of a
   toctree for files in `doc/`.
+- Mark external links with an icon (sphinx-rtd-theme setting `style_external_links`).
 
 ## [1.1.1] - 2022-11-11
 ### Fixed

--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -109,7 +109,9 @@ if not on_rtd:
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'style_external_links': True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
## Description

Enable the `style_external_links` setting of the sphinx_rtd_theme to show a small icon next external links.  It looks like this:

![image](https://user-images.githubusercontent.com/9333121/203825732-62086b71-1322-4967-b040-729711ae3fc7.png)


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
