### PR TITLE
Set html_logo through config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Config parameter `html.logo` to specify an image that is shown in the top of
+  the navigation bar.
 
 
 ## [1.2.0] - 2022-11-24

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ exclude_patterns = []
 # foo = "docs.foo.org"
 
 
+[html]
+# Path to an image that is shown at the top of the navigation bar.
+# The image should be located inside the "doc/" folder and the path given relative to
+# the package root.
+# Example:
+# logo = "doc/images/logo.png"
+logo = ""
+
+
 [mainpage]
 # Custom title for the main page.  If not set "Welcome to {package}'s documentation!" is
 # used.

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -775,6 +775,7 @@ def build_documentation(
             .replace("@PROJECT_VERSION@", project_version)
             .replace("@DOXYGEN_XML_OUTPUT@", str(doc_build_dir / "doxygen" / "xml"))
             .replace("@INTERSPHINX_MAPPING@", intersphinx_mapping)
+            .replace("@LOGO@", config["html"]["logo"])
         )
     with open(doc_build_dir / "conf.py", "wt") as f:
         f.write(out_text)

--- a/breathing_cat/config.py
+++ b/breathing_cat/config.py
@@ -21,6 +21,9 @@ _DEFAULT_CONFIG: typing.Dict[str, typing.Any] = {
         "title": None,
         "auto_general_docs": True,
     },
+    "html": {
+        "logo": "",
+    },
 }
 
 

--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -123,6 +123,8 @@ html_css_files = [
     "custom.css",
 ]
 
+html_logo = "@LOGO@"
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
## Description

Simple gimmick to make the docs look cooler:  Add a parameter `html.logo` to the config file which can be used to specify an image used for sphinx' `html_logo` (will be shown below the package name at at the top of the navigation bar).
This can be useful to more easily distinguish which package/project the documentation belongs to.

Example how it looks like:
![image](https://user-images.githubusercontent.com/9333121/204540529-c75fdd50-1257-4301-8930-e20eaf44cd80.png)


## How I Tested

By building with and without the parameter set.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
