### PR TITLE
Do not show private members in C++ API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config parameter `html.logo` to specify an image that is shown in the top of
   the navigation bar.
 
+### Changed
+- Private members of C++ classes are not shown anymore.  This affects the
+  auto-generated API documentation as well as usages of `.. doxygenclass::` in
+  the general documentation.  In the latter they can be added back if desired by
+  specifying `:private-members:`.
+
 
 ## [1.2.0] - 2022-11-24
 ### Added

--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -67,7 +67,7 @@ templates_path = ["_templates"]
 # breath extension management
 breathe_projects = {project: "@DOXYGEN_XML_OUTPUT@"}
 breathe_default_project = project
-breathe_default_members = ("members", "private-members", "undoc-members")
+breathe_default_members = ("members", "undoc-members")
 
 # cmake parsing
 # primary_domain = 'cmake'


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Private members of C++ classes are not shown anymore.  This mostly affects the auto-generated API documentation but also usages of `.. doxygenclass::` in the general documentation.  In the latter they can be added back if desired by specifying `:private-members:`.

This is an somewhat opinionated change and open to debate, though.  I would say that private members are not relevant for a normal user as they cannot be accessed anyway.  Thus the documentation would be clearer without them.
But if you see some use in having them included, I'm good with that as well.

## How I Tested

Build and verified that the private members disappeared.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
