### PR TITLE
Create symlink PKG to package directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Config parameter `html.logo` to specify an image that is shown in the top of
   the navigation bar.
+- Create a symlink called `PKG` in the build directory that points to the project source
+  directory.  This allows, for example, to include example scripts from the source
+  directory into RST files, using a path like `/PKG/scripts/example.py`.
 
 ### Changed
 - Private members of C++ classes are not shown anymore.  This affects the

--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ auto_general_docs = true
 ```
 
 
+Include Files From Source Directory in the Documentation
+--------------------------------------------------------
+
+You may want to include files from the package into the documentation text.  For example
+the package may contain a file `scripts/example.py` which could normally be included in
+a file `doc/examples.rst` like this:
+
+```rst
+.. literalinclude:: ../scripts/example.py
+```
+
+With breathing cat, this unfortunately doesn't work, as all the documentation files are
+copied to a separate build directory and processed there.  From within this build
+directory, the relative path given above cannot be resolved.  However, a symlink called
+"PKG" is created in the build directory and points to the package source directory.  So
+instead of the above, you can use the following (note the leading `/`):
+
+```rst
+.. literalinclude:: /PKG/scripts/example.py
+```
+
+
 Assumptions Regarding Package Structure
 ---------------------------------------
 

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -769,6 +769,10 @@ def build_documentation(
     except FileNotFoundError:
         pass  # simply don't add general documentation if no doc files exist
 
+    # Link project_source_dir as PKG in build directory.  This allows, for example, to
+    # include source files from the package using a path like `/PKG/scripts/foo.py`.
+    os.symlink(project_source_dir, doc_build_dir / "PKG", target_is_directory=True)
+
     #
     # Copy the license and readme file.
     #

--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -89,7 +89,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["internal/*"]
+exclude_patterns = ["internal/*", "PKG/*"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -328,6 +328,10 @@ def test_build_documentation_default(tmp_path, ros_pkg_path):
     index_rst_content = index_rst_file.read_text()
     assert "@" not in index_rst_content
 
+    # verify that the PKG symlink was created
+    assert (tmp_path / "PKG").is_symlink()
+    assert (tmp_path / "PKG" / "package.xml").exists()
+
 
 def test_build_documentation_mainpage_config(tmp_path, ros_pkg_path, test_configs):
     # just a very basic test if index.html is created


### PR DESCRIPTION
## Description
I wanted to include some example scripts in a file inside `doc/` using
```rst
.. literalinclude:: ../scripts/example.py
```
However, this failed because the files from `doc/` are copied to the build directory and there the other packages are not available and thus the relative path could not be resolved.

To work around this problem, this PR adds a line to create a symlink "PKG" to the package source directory in the build directory.  This allows including source files using a path like `/PKG/scripts/example.py`.

Not sure if this is the best solution but it seemed to be the most flexible one and was easy to implement.

## How I Tested

Added a check in the unit tests and also built the documentation for a package using the feature.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
