### PR TITLE
List content of actual module before submodules in Python API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Python API: List content of actual module before submodules
 
 
 ## [1.3.0] - 2023-03-14

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -267,20 +267,20 @@ def _build_sphinx_api_doc(doc_build_dir: Path, python_source_dir: Path) -> None:
         sphinx_apidoc_input = str(python_source_dir)
         sphinx_apidoc_output = str(doc_build_dir)
 
-        command = (
-            sphinx_apidoc
-            + " --separate "
-            + " -o "
-            + sphinx_apidoc_output
-            + " "
-            + sphinx_apidoc_input
-        )
+        command = [
+            sphinx_apidoc,
+            "--separate",
+            "-o",
+            sphinx_apidoc_output,
+            sphinx_apidoc_input,
+        ]
+
         process = subprocess.Popen(
-            command.split(), stdout=subprocess.PIPE, cwd=str(doc_build_dir)
+            command, stdout=subprocess.PIPE, cwd=str(doc_build_dir)
         )
         output, error = process.communicate()
         print("\n------------------------------------------------------------------")
-        print("$ {}\n\n".format(command))
+        print("$ {}\n\n".format(" ".join(command)))
         print("sphinx-apidoc output:\n", output.decode("UTF-8"))
         print("sphinx-apidoc error:\n", error)
 

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -269,6 +269,7 @@ def _build_sphinx_api_doc(doc_build_dir: Path, python_source_dir: Path) -> None:
 
         command = [
             sphinx_apidoc,
+            "--module-first",
             "--separate",
             "-o",
             sphinx_apidoc_output,


### PR DESCRIPTION
## Description
By default the API page of a Python module lists first all the submodules with their content and only then the content of the module itself.  Adding the `--module-first`  flag to `sphinx-apidoc` reverses this, which seems more logical to me (the content of the main module is often more important than that of submodules).

Example:
![image](https://user-images.githubusercontent.com/9333121/225011238-ad824cb4-ed57-428e-8aef-95f3ccea65eb.png)


## How I Tested

Build documentation of a package using this branch.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
