### PR TITLE
Add options --skip-cpp, --skip-python and --skip-cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Options ``--skip-cpp``, ``--skip-python`` and ``--skip-cmake`` to disable
+  auto-generated API documentation for the corresponding language.
 
 
 ## [1.3.1] - 2023-03-20

--- a/breathing_cat/__main__.py
+++ b/breathing_cat/__main__.py
@@ -1,3 +1,4 @@
+"""Script to run breathing cat."""
 import argparse
 import logging
 import pathlib
@@ -66,6 +67,19 @@ def main() -> int:
         """,
     )
     parser.add_argument(
+        "--skip-cpp", action="store_true", help="Do not include C++ API documentation."
+    )
+    parser.add_argument(
+        "--skip-python",
+        action="store_true",
+        help="Do not include Python API documentation.",
+    )
+    parser.add_argument(
+        "--skip-cmake",
+        action="store_true",
+        help="Do not include CMake API documentation.",
+    )
+    parser.add_argument(
         "--force",
         "-f",
         action="store_true",
@@ -115,6 +129,9 @@ def main() -> int:
         args.package_version,
         python_pkg_path=args.python_dir,
         config_file=args.config,
+        skip_cpp=args.skip_cpp,
+        skip_python=args.skip_python,
+        skip_cmake=args.skip_cmake,
     )
 
     return 0

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -649,7 +649,7 @@ def _construct_intersphinx_mapping_config(
             str,
             t.Mapping[t.Literal["target", "inventory"], t.Optional[str]],
         ],
-    ]
+    ],
 ) -> str:
     """Construct argument for intersphinx_mapping parameter.
 
@@ -703,6 +703,9 @@ def build_documentation(
     project_version: str,
     python_pkg_path: t.Optional[StrPath] = None,
     config_file: t.Optional[StrPath] = None,
+    skip_cpp: bool = False,
+    skip_python: bool = False,
+    skip_cmake: bool = False,
 ) -> None:
     """Build the documentation.
 
@@ -716,6 +719,9 @@ def build_documentation(
             functions) are included as well.
         config_file:  Path to the breathing-cat config file.  If not set, it is searched
             for in project_source_dir.
+        skip_cpp:  Do not auto-generate C++ API documentation.
+        skip_python:  Do not auto-generate Python API documentation.
+        skip_cmake:  Do not auto-generate CMake API documentation.
     """
     # make sure all paths are of type Path
     doc_build_dir = Path(build_dir)
@@ -749,15 +755,23 @@ def build_documentation(
 
     # String to replace in the main index.rst
 
-    cpp_api = _search_for_cpp_api(
-        doc_build_dir, project_source_dir, resource_dir, config
+    cpp_api = (
+        _search_for_cpp_api(doc_build_dir, project_source_dir, resource_dir, config)
+        if not skip_cpp
+        else ""
     )
 
-    python_api = _search_for_python_api(
-        doc_build_dir, project_source_dir, python_pkg_path
+    python_api = (
+        _search_for_python_api(doc_build_dir, project_source_dir, python_pkg_path)
+        if not skip_python
+        else ""
     )
 
-    cmake_api = _search_for_cmake_api(doc_build_dir, project_source_dir, resource_dir)
+    cmake_api = (
+        _search_for_cmake_api(doc_build_dir, project_source_dir, resource_dir)
+        if not skip_cmake
+        else ""
+    )
 
     general_documentation = ""
     try:


### PR DESCRIPTION
## Description

To disable auto-generated API documentation for the corresponding language.

I added it to be able to significantly speed up the build while testing changes on non-API parts of the documentation locally but it might be useful in other situations as well.

## How I Tested

Tested by running on a package locally (only with cpp and python, though). 