### PR TITLE
Add custom confval directive/role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Options ``--skip-cpp``, ``--skip-python`` and ``--skip-cmake`` to disable
+- Options `--skip-cpp`, `--skip-python` and `--skip-cmake` to disable
   auto-generated API documentation for the corresponding language.
+- Custom `confval` directive and role for documenting configuration parameters.
 
 
 ## [1.3.1] - 2023-03-20

--- a/README.md
+++ b/README.md
@@ -175,6 +175,30 @@ package:
   toctree.
 
 
+
+Special Directives/Roles
+------------------------
+
+### confval
+
+The `confval` directive can be used to specify configuration values.  It will be
+rendered similarly like a class member and can be linked to.  Further the `confval` role
+can be used to reference it in other parts for the documentation.
+
+Example:
+
+```rst
+.. confval:: enable_foo: bool = False
+
+   Here is some description of the parameter.
+   Note that the type annotation and default value are both optional.
+
+...
+
+To reference the option, use :confval:`enable_foo`.
+```
+
+
 Copyright & License
 -------------------
 

--- a/breathing_cat/__main__.py
+++ b/breathing_cat/__main__.py
@@ -1,4 +1,5 @@
 """Script to run breathing cat."""
+
 import argparse
 import logging
 import pathlib

--- a/breathing_cat/build.py
+++ b/breathing_cat/build.py
@@ -3,6 +3,7 @@
 License BSD-3-Clause
 Copyright (c) 2021, New York University and Max Planck Gesellschaft.
 """
+
 from __future__ import annotations
 
 import collections.abc

--- a/breathing_cat/find_version.py
+++ b/breathing_cat/find_version.py
@@ -1,4 +1,5 @@
 """Functions for auto-detecting the version of the package."""
+
 from __future__ import annotations
 
 import logging

--- a/breathing_cat/resources/sphinx/conf.py.in
+++ b/breathing_cat/resources/sphinx/conf.py.in
@@ -5,7 +5,11 @@
 
 import datetime
 import os
+import re
 import sys
+
+import docutils.nodes
+import sphinx
 
 # -- Path setup --------------------------------------------------------------
 
@@ -146,3 +150,73 @@ intersphinx_mapping = @INTERSPHINX_MAPPING@
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+
+object_description_options = [
+    ("std:confval", dict(toc_icon_class="data", toc_icon_text="C")),
+]
+
+
+def setup(app):
+    def confval_parse_format(env, sig, node):
+        # Parse confval values for add_object_type().  Possible signatures are:
+        # - foo
+        # - foo: type
+        # - foo = default_value
+        # - foo: type = default_value
+
+        # From Sphinx docs:
+        # If you provide parse_node, it must be a function that takes a string and a
+        # docutils node, and it must populate the node with children parsed from the
+        # string. It must then return the name of the item to be used in
+        # crossreferencing and index entries. See the conf.py file in the source for
+        # this documentation for an example
+
+        m = re.match(r"([a-zA-Z0-9_.]+)\s*(:([^=]+))?\s*(=(.+))?", sig)
+        assert m is not None
+
+        name = m.group(1)
+        value_type = m.group(3)
+        default_value = m.group(5)
+
+        name_parts = name.rsplit(".", maxsplit=1)
+        if len(name_parts) > 1:
+            node += sphinx.addnodes.desc_classname(name_parts[0])
+        node += sphinx.addnodes.desc_name(name_parts[-1], name_parts[-1])
+
+        if value_type is not None:
+            node += sphinx.addnodes.desc_sig_punctuation(" : ", " : ")
+            node += sphinx.addnodes.desc_type("", value_type)
+
+        if default_value is not None:
+            node += sphinx.addnodes.desc_sig_punctuation(" = ", " = ")
+
+            node += docutils.nodes.literal(
+                default_value,
+                default_value,
+                classes=["code", "highlight"],
+            )
+
+        return name
+
+    # Custom `confval` directive for more nicely documenting configuration values.
+    #
+    # Usage example:
+    # ```
+    # .. confval:: enable_foo: bool = False
+    #
+    #    Specifies whether the Foo is enabled or not.  Off by default.
+    # ```
+    # Both the type annotation and default value are optional.
+    #
+    # It is then also possible to reference it in other parts of the docs:
+    # ```
+    # This package supports the Foo, see :confval:`enable_foo`.
+    # ```
+    app.add_object_type(
+        "confval",
+        "confval",
+        objname="configuration value",
+        indextemplate="pair: %s; configuration value",
+        parse_node=confval_parse_format,
+    )


### PR DESCRIPTION
## Description

The `confval` directive can be used to specify configuration values.  It will be rendered similarly like a class member and can be linked to. Further the `confval` role can be used to reference it in other parts for the documentation.

Example:

```rst
.. confval:: enable_foo: bool = False

   Here is some description of the parameter.
   Note that the type annotation and default value are both optional.

...

To reference the option, use :confval:`enable_foo`.
```

This is mostly copied from what I added in [cluster_utils](https://github.com/martius-lab/cluster_utils/pull/100) with some small changes to make it more general.

When used, it looks like this:
![image](https://github.com/machines-in-motion/breathing-cat/assets/9333121/7e5a4391-bccc-4bdd-a0d2-1d4dbcae6e33)


## How I Tested

Used to build some documentation using `confval`.