### PR TITLE
Prepare release of 1.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
-    runs-on: ubuntu-20.04
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [1.4.0] -- 2024-07-01
 ### Added
 - Options `--skip-cpp`, `--skip-python` and `--skip-cmake` to disable
   auto-generated API documentation for the corresponding language.
@@ -86,7 +89,10 @@ Extracted the documentation build code from
 some minor changes. 
 
 
-[Unreleased]: https://github.com/machines-in-motion/breathing-cat/compare/v1.3.1...HEAD
+---
+
+[Unreleased]: https://github.com/machines-in-motion/breathing-cat/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/machines-in-motion/breathing-cat/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/machines-in-motion/breathing-cat/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/machines-in-motion/breathing-cat/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/machines-in-motion/breathing-cat/compare/v1.1.1...v1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 
 [project]
 name = "breathing_cat"
-version = "1.3.1"
+dynamic = ["version"]
 description = "Tool to build documentation for C++/Python-Packages used at MPI-IS"
 authors = [
     {name = "Maximilien Naveau"},
@@ -49,3 +49,6 @@ bcat = "breathing_cat.__main__:main"
 
 [tool.setuptools.package-data]
 breathing_cat = ["resources/**/*.in"]
+
+[tool.setuptools_scm]
+# nothing to configure here, but section needs to exist to enable setuptools_scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",
 ]


### PR DESCRIPTION
## Description

- Also run tests on Python 3.12 and add classifier
- Use setuptools_scm to get version from git (so we don't need to update manually in the pyproject.toml)
- Update CHANGELOG