### PR TITLE
Add @rst/@endrst commands to Doxygen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `@rst/@endrst` aliases to Doxygen config.  This makes it easier to use RST (e.g.
+  for references) in Doxygen blocks.
 
 
 ## [1.4.0] -- 2024-07-01

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ package:
 
 
 
-Special Directives/Roles
-------------------------
+Special Directives/Roles/etc.
+-----------------------------
 
 ### confval
 
@@ -196,6 +196,22 @@ Example:
 ...
 
 To reference the option, use :confval:`enable_foo`.
+```
+
+
+### Using RST in Doxygen
+
+You can use the `@rst/@endrst` commands in Doxygen to use restructured text inside
+Doxygen comment blocks, e.g. for references.  Example:
+
+```
+/**
+ * @brief Do some foobar.
+ *
+ * @rst
+ * For the theory behind this, see :ref:`foobar_theory`.
+ * @endrst
+ */
 ```
 
 

--- a/breathing_cat/resources/doxygen/Doxyfile.in
+++ b/breathing_cat/resources/doxygen/Doxyfile.in
@@ -50,3 +50,7 @@ STRIP_FROM_PATH = @PROJECT_SOURCE_DIR@
 ALIASES += imageSize{3}="\htmlonly <style> div.image img[src=\"\1\"]{\2} </style> \endhtmlonly \image html \1 \"\3\""
 # add a `\license` tag
 ALIASES += "license=\xrefitem license \"License\" \"License\" "
+
+# Allow for rst directives and advanced functions e.g. grid tables
+ALIASES += "rst=\verbatim embed:rst:leading-asterisk"
+ALIASES += "endrst=\endverbatim"


### PR DESCRIPTION
## Description

These are just aliases for `@verbatim` that make it easier to embed restructured text in Doxygen comments.  This is, for example, useful for adding references to other non-doxygen parts of the documentation.

See the change in the README on how to use it.


## How I Tested

By using it in a local documentation build.